### PR TITLE
Update plugin version in example documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The plugin is configured in `build.gradle` as follows:
 
 ```
 plugins {
-    id 'org.beryx.jlink' version '2.4.1'
+    id 'org.beryx.jlink' version '2.23.6'
     ...
 }
 


### PR DESCRIPTION
Change required plugin version to current version. Using version 2.4.1 result in an error with current gradle version ("Please use the ObjectFactory.mapProperty() method to create a property of type Map<K, V>.")